### PR TITLE
Fix babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "tslint-eslint-rules": "^5.0.0",
     "tslint-microsoft-contrib": "^5.0.3",
     "tslint-react": "^3.5.1",
-    "typescript-eslint-parser": "^14.0.0"
+    "typescript-eslint-parser": "^14.0.0",
+    "babel-eslint": "^8.2.2"
   },
   "devDependencies": {
     "@hollowverse/clown": "^0.0.3",
     "@hollowverse/utils": "^4.1.4",
     "@hollowverse/validate-filenames": "^1.4.0",
-    "babel-eslint": "^8.2.2",
     "del-cli": "^1.1.0",
     "husky": "^0.15.0-rc.8",
     "lint-staged": "^7.0.0",


### PR DESCRIPTION
As a transitive dependency, `babel-eslint` should be in `dependencies`, not `devDependencies`.