### PR TITLE
Feature: improve semantic-release

### DIFF
--- a/semanticRelease/.releaserc.json
+++ b/semanticRelease/.releaserc.json
@@ -12,8 +12,19 @@
   },
   "generateNotes": {
     "preset": "angular",
+    "parserOpts": {
+      "noteKeywords": [
+        "fix",
+        "Fix",
+        "Feature",
+        "feature",
+        "breaking",
+        "Breaking"
+      ]
+    },
     "writerOpts": {
-      "commitsSort": ["subject", "type"]
+      "generateOn": "type",
+      "commitsSort": "type"
     }
   }
 }

--- a/semanticRelease/.releaserc.json
+++ b/semanticRelease/.releaserc.json
@@ -9,5 +9,11 @@
       { "type": "breaking", "release": "major" },
       { "type": "Breaking", "release": "major" }
     ]
+  },
+  "generateNotes": {
+    "preset": "angular",
+    "writerOpts": {
+      "commitsSort": ["subject", "type"]
+    }
   }
 }

--- a/semanticRelease/.releaserc.json
+++ b/semanticRelease/.releaserc.json
@@ -23,8 +23,8 @@
       ]
     },
     "writerOpts": {
-      "generateOn": "type",
-      "commitsSort": "type"
+      "commitsSort": "type",
+      "transform": {}
     }
   }
 }

--- a/semanticRelease/.releaserc.json
+++ b/semanticRelease/.releaserc.json
@@ -12,19 +12,11 @@
   },
   "generateNotes": {
     "preset": "angular",
-    "parserOpts": {
-      "noteKeywords": [
-        "fix",
-        "Fix",
-        "Feature",
-        "feature",
-        "breaking",
-        "Breaking"
-      ]
-    },
     "writerOpts": {
       "commitsSort": "type",
       "transform": {}
     }
-  }
+  },
+  "success": [],
+  "fail": []
 }


### PR DESCRIPTION
This PR improves semantic-release by making it generate a rudimentary changelog (as opposed to not having any changelog at all as before), and disabling the celebration and warnings for success and failure events.