### PR TITLE
Breaking: Rename tslint command to lint-ts, remove color flag from jest command

### DIFF
--- a/clown/jest/package.json
+++ b/clown/jest/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "jest": "TZ=UTC NODE_ENV=test jest --colors"
+    "jest": "TZ=UTC NODE_ENV=test jest"
   },
   "jest": {
     "transform": {

--- a/clown/typescript/package.json
+++ b/clown/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "check-ts": "tsc --project . --noEmit",
-    "tslint": "tslint 'src/**/*.ts' --project ."
+    "lint-ts": "tslint 'src/**/*.ts' --project ."
   },
   "devDependencies": {
     "typescript": "^2.8.1",


### PR DESCRIPTION
Having a command named with the same name as a local binary makes it impossible to run the binary with `yarn`:

```
yarn tslint
```

The command `"tslint"` in `"scripts"` always takes precedence over `./node_modules/.bin/tslint`.