### PR TITLE
Breaking: upgrade babel packages, include stage-3, update ESLint config for TS 

### DIFF
--- a/babel/node/.babelrc
+++ b/babel/node/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "@babel/stage-3",
     [
       "@babel/env",
       {
@@ -10,10 +11,7 @@
       }
     ]
   ],
-  "plugins": [
-    "@babel/proposal-object-rest-spread",
-    "@babel/transform-runtime"
-  ],
+  "plugins": ["@babel/transform-runtime"],
   "sourceMap": "both",
   "retainLines": true
 }

--- a/clown/babel/package.json
+++ b/clown/babel/package.json
@@ -7,18 +7,18 @@
     }
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.44",
-    "@babel/polyfill": "^7.0.0-beta.44"
+    "@babel/runtime": "^7.0.0-beta.46",
+    "@babel/polyfill": "^7.0.0-beta.46"
   },
   "resolutions": {
     "babel-core": "^7.0.0-bridge.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.44",
-    "@babel/core": "^7.0.0-beta.44",
-    "@babel/node": "^7.0.0-beta.44",
-    "@babel/preset-env": "^7.0.0-beta.44",
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.44",
-    "@babel/plugin-transform-runtime": "^7.0.0-beta.44"
+    "@babel/cli": "^7.0.0-beta.46",
+    "@babel/core": "^7.0.0-beta.46",
+    "@babel/node": "^7.0.0-beta.46",
+    "@babel/preset-env": "^7.0.0-beta.46",
+    "@babel/preset-stage-3": "^7.0.0-beta.46",
+    "@babel/plugin-transform-runtime": "^7.0.0-beta.46"
   }
 }

--- a/eslint/react/typescript/.eslintrc.json
+++ b/eslint/react/typescript/.eslintrc.json
@@ -17,6 +17,7 @@
     "react/void-dom-elements-no-children": "error",
     "react/no-multi-comp": ["error", { "ignoreStateless": true }],
     "react/jsx-pascal-case": "error",
-    "react/jsx-no-target-blank": "error"
+    "react/jsx-no-target-blank": "error",
+    "no-multi-str": ["off"]
   }
 }

--- a/eslint/typescript/.eslintrc.json
+++ b/eslint/typescript/.eslintrc.json
@@ -7,7 +7,11 @@
   "rules": {
     "typescript/no-unused-vars": ["error"],
     "no-undefined": ["off"],
-    "no-undef": ["off"]
+    "no-undef": ["off"],
+    "no-restricted-syntax": ["off"],
+    "no-unused-vars": ["off"],
+    "no-restricted-globals": ["off"],
+    "import/first": ["off"]
   },
   "settings": {
     "import/resolver": {

--- a/eslint/typescript/.eslintrc.json
+++ b/eslint/typescript/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "parser": "typescript-eslint-parser",
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "plugins": ["typescript"],
   "rules": {
     "typescript/no-unused-vars": ["error"],


### PR DESCRIPTION
Turns out `@babel/preset-env` does not always include stage 3 proposal, which includes things like optional catch binding syntax and object rest spread. I think it's safe to include stage 3 syntax.