### PR TITLE
 Breaking: Add CSSTree validator

### DIFF
--- a/clown/stylelint/.vscode/settings.json
+++ b/clown/stylelint/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "files.associations": {
     "**/.stylelintrc": "json"
-  }
+  },
+  "css.validate": false,
+  "scss.validate": false
 }

--- a/clown/stylelint/package.json
+++ b/clown/stylelint/package.json
@@ -10,6 +10,7 @@
     "@types/stylelint": "^7.10.0",
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^17.0.0",
-    "stylelint-no-unsupported-browser-features": "^1.0.0"
+    "stylelint-no-unsupported-browser-features": "^1.0.0",
+    "stylelint-csstree-validator": "^1.2.2"
   }
 }

--- a/stylelint/.stylelintrc.json
+++ b/stylelint/.stylelintrc.json
@@ -10,7 +10,10 @@
     "selector-no-vendor-prefix": [true],
     "property-no-vendor-prefix": [true],
     "value-no-vendor-prefix": [true],
-    "property-blacklist": ["margin-bottom", "margin-right", "margin"]
+    "property-blacklist": ["margin-bottom", "margin-right", "margin"],
+    "csstree/validator": {
+      "ignore": ["composes"]
+    }
   },
   "ignoreFiles": ["./coverage/**/*"]
 }

--- a/stylelint/.stylelintrc.json
+++ b/stylelint/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
   "plugins": [
-    "stylelint-no-unsupported-browser-features"
+    "stylelint-no-unsupported-browser-features",
+    "stylelint-csstree-validator"
   ],
   "rules": {
     "plugin/no-unsupported-browser-features": [true],
@@ -11,7 +12,5 @@
     "value-no-vendor-prefix": [true],
     "property-blacklist": ["margin-bottom", "margin-right", "margin"]
   },
-  "ignoreFiles": [
-    "./coverage/**/*"
-  ]
+  "ignoreFiles": ["./coverage/**/*"]
 }


### PR DESCRIPTION
This provides some kind of "type checking" for CSS. CSSTree Validator checks that the values of CSS properties are valid. Adding this plugin also enables immediate feedback in VS Code (provided that the recommended stylelint plugin is installed).

![screenshot from 2018-05-05 14-46-44](https://user-images.githubusercontent.com/1012761/39662969-44f6ca7e-5073-11e8-9077-5eb8c2ee0106.png)

![screenshot from 2018-05-05 14-46-31](https://user-images.githubusercontent.com/1012761/39662965-347ca628-5073-11e8-9e3d-179ca6c749f9.png)
