### PR TITLE
Breaking: Add more stylelint rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,6 @@
   ],
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
-  "[json]": {
-    "editor.formatOnSave": false
-  },
   "typescript.implementationsCodeLens.enabled": true,
   "typescript.referencesCodeLens.enabled": true,
   "files.exclude": {

--- a/clown/css/package.json
+++ b/clown/css/package.json
@@ -7,12 +7,14 @@
     ]
   },
   "devDependencies": {
-    "@types/stylelint": "^7.10.0",
-    "stylelint": "^8.4.0",
-    "stylelint-config-standard": "^17.0.0",
-    "stylelint-no-unsupported-browser-features": "^1.0.0",
+    "eslint-plugin-css-modules": "^2.7.5",
+    "@types/stylelint": "^7.11.0",
+    "stylelint": "^9.3.0",
+    "stylelint-config-standard": "^18.2.0",
+    "stylelint-no-unsupported-browser-features": "^3.0.0",
     "stylelint-csstree-validator": "^1.2.2",
-
-    "eslint-plugin-css-modules": "^2.7.5"
+    "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
+    "stylelint-declaration-strict-value": "^1.0.4",
+    "stylelint-high-performance-animation": "^1.1.0"
   }
 }

--- a/clown/css/package.json
+++ b/clown/css/package.json
@@ -14,7 +14,7 @@
     "stylelint-no-unsupported-browser-features": "^3.0.0",
     "stylelint-csstree-validator": "^1.2.2",
     "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
-    "stylelint-declaration-strict-value": "^1.0.4",
+    "stylelint-declaration-use-variable": "^1.0.0",
     "stylelint-high-performance-animation": "^1.1.0"
   }
 }

--- a/stylelint/.stylelintrc.json
+++ b/stylelint/.stylelintrc.json
@@ -4,7 +4,7 @@
     "stylelint-csstree-validator",
     "stylelint-declaration-block-no-ignored-properties",
     "stylelint-high-performance-animation",
-    "stylelint-declaration-strict-value"
+    "stylelint-declaration-use-variable"
   ],
   "rules": {
     "plugin/no-unsupported-browser-features": [true],
@@ -20,16 +20,12 @@
     "plugin/no-low-performance-animation-properties": [
       true,
       {
-        "ignore": "paint-properties"
+        "ignore": "paint-properties",
+        "ignoreProperties": ["color", "background-color"]
       }
     ],
-    "scale-unlimited/declaration-strict-value": [
-      ["z-index"],
-      {
-        "ignoreFunctions": true
-      }
-    ],
-    "plugin/declaration-block-no-ignored-properties": true
+    "plugin/declaration-block-no-ignored-properties": true,
+    "sh-waqar/declaration-use-variable": [["/margin/", "/padding/", "z-index"]]
   },
   "ignoreFiles": ["./coverage/**/*"]
 }

--- a/stylelint/.stylelintrc.json
+++ b/stylelint/.stylelintrc.json
@@ -1,19 +1,35 @@
 {
   "plugins": [
     "stylelint-no-unsupported-browser-features",
-    "stylelint-csstree-validator"
+    "stylelint-csstree-validator",
+    "stylelint-declaration-block-no-ignored-properties",
+    "stylelint-high-performance-animation",
+    "stylelint-declaration-strict-value"
   ],
   "rules": {
     "plugin/no-unsupported-browser-features": [true],
-    "at-rule-no-vendor-prefix": [true],
-    "media-feature-name-no-vendor-prefix": [true],
-    "selector-no-vendor-prefix": [true],
-    "property-no-vendor-prefix": [true],
-    "value-no-vendor-prefix": [true],
+    "at-rule-no-vendor-prefix": true,
+    "media-feature-name-no-vendor-prefix": true,
+    "selector-no-vendor-prefix": true,
+    "property-no-vendor-prefix": true,
+    "value-no-vendor-prefix": true,
     "property-blacklist": ["margin-bottom", "margin-right", "margin"],
     "csstree/validator": {
       "ignore": ["composes"]
-    }
+    },
+    "plugin/no-low-performance-animation-properties": [
+      true,
+      {
+        "ignore": "paint-properties"
+      }
+    ],
+    "scale-unlimited/declaration-strict-value": [
+      ["z-index"],
+      {
+        "ignoreFunctions": true
+      }
+    ],
+    "plugin/declaration-block-no-ignored-properties": true
   },
   "ignoreFiles": ["./coverage/**/*"]
 }


### PR DESCRIPTION
* [x] `declaration-block-no-ignored-properties`: prevents combinations of CSS properties that do not make sense together, like `width: 100px` with `display: inline-block`.
* [x] `no-low-performance-animation-properties`: prevents transitions and animations of properties that are known to trigger layout/paint.
* [x] `stylelint-declaration-strict-value`: requires some properties to use variables or Sass functions. Useful for `z-index` to avoid messing up the stacking order of layers by defining all the values in one place.
* [ ] More...?